### PR TITLE
Improve README Images & Add Git Info to Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://www.getnacelle.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
-    <img alt="Nacelle" src="./example/src/images/nacelle-rocket-icon-crop.png" width="60" />
+    <img alt="Nacelle" src="https://raw.githubusercontent.com/getnacelle/gatsby-theme-nacelle/master/example/src/images/nacelle-rocket-icon-crop.png" width="60" />
   </a>
 </p>
 <h1 align="center">

--- a/example/README.md
+++ b/example/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://www.getnacelle.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
-    <img alt="Nacelle" src="./src/images/nacelle-rocket-icon-crop.png" width="60" />
+    <img alt="Nacelle" src="https://raw.githubusercontent.com/getnacelle/gatsby-theme-nacelle/master/example/src/images/nacelle-rocket-icon-crop.png" width="60" />
   </a>
 </p>
 

--- a/gatsby-theme-nacelle/README.md
+++ b/gatsby-theme-nacelle/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://www.getnacelle.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
-    <img alt="Nacelle" src="../example/src/images/nacelle-rocket-icon-crop.png" width="60" />
+    <img alt="Nacelle" src="https://raw.githubusercontent.com/getnacelle/gatsby-theme-nacelle/master/example/src/images/nacelle-rocket-icon-crop.png" width="60" />
   </a>
 </p>
 
@@ -13,15 +13,16 @@ This Gatsby theme effectively functions as a plugin to connect to a [Nacelle](ht
 
 ## What is Nacelle?
 
-Nacelle is a headless eCommerce platform made for developers who want to create superior customer buying experiences. When you connect your Shopify, Magento, or custom eCommerce store to Nacelle, our proprietary indexing system supplies a high-performance connection to your back end. 
+Nacelle is a headless eCommerce platform made for developers who want to create superior customer buying experiences. When you connect your Shopify, Magento, or custom eCommerce store to Nacelle, our proprietary indexing system supplies a high-performance connection to your back end.
 
 To learn more, check out the [Nacelle docs](https://docs.getnacelle.com/intro.html#what-is-nacelle).
 
 ## Quick Start
 
-Follow these steps to add `gatsby-theme-nacelle` to your  Gatsby site:
+Follow these steps to add `gatsby-theme-nacelle` to your Gatsby site:
 
 ### Install
+
 #### With Yarn
 
 ```shell
@@ -46,7 +47,7 @@ module.exports = {
   plugins: [
     {
       resolve: "gatsby-theme-nacelle",
-      options: {  
+      options: {
         nacelle_space_id: YOUR_NACELLE_SPACE_ID,
         nacelle_graphql_token: YOUR_NACELLE_GRAPHQL_TOKEN
       }
@@ -59,23 +60,23 @@ module.exports = {
 
 Install [dotenv](https://www.npmjs.com/package/dotenv), then create a `.env` file with your Nacelle credentials. For more information about using environment variables in a Gatsby project, check out the [Gatsby docs](https://www.gatsbyjs.org/docs/environment-variables/).
 
-```  
+```
 # .env
-NACELLE_SPACE_ID="your-nacelle-space-id"  
+NACELLE_SPACE_ID="your-nacelle-space-id"
 NACELLE_GRAPHQL_TOKEN="your-nacelle-graphql-token"
 ```
 
 ```javascript
 // gatsby-config.js`
-require('dotenv').config()
+require("dotenv").config();
 
 module.exports = {
   plugins: [
     {
       resolve: "gatsby-theme-nacelle",
-      options: {  
-      	nacelle_space_id: process.env.NACELLE_SPACE_ID,
-      	nacelle_graphql_token: process.env.NACELLE_GRAPHQL_TOKEN
+      options: {
+        nacelle_space_id: process.env.NACELLE_SPACE_ID,
+        nacelle_graphql_token: process.env.NACELLE_GRAPHQL_TOKEN
       }
     }
   ]

--- a/gatsby-theme-nacelle/package.json
+++ b/gatsby-theme-nacelle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/gatsby-theme-nacelle",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Gatsby theme for loading data from the Nacelle Hail Frequency API",
   "keywords": [
     "gatsby",
@@ -15,6 +15,11 @@
   ],
   "main": "index.js",
   "author": "Nacelle Inc. (getnacelle.com)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getnacelle/gatsby-theme-nacelle",
+    "directory": "gatsby-theme-nacelle"
+  },
   "license": "ISC",
   "peerDependencies": {
     "gatsby": "^2.6.0"


### PR DESCRIPTION
### What Does This Do?
- Uses full URLs to hosted images (instead of relative links to local files) in READMEs
  - Should enable Nacelle icon to show up on https://www.npmjs.com/package/@nacelle/gatsby-theme-nacelle
- Adds git field to package.json
  - Should add repo link to https://www.npmjs.com/package/@nacelle/gatsby-theme-nacelle