### PR TITLE
Fix package name (add organization namespace)

### DIFF
--- a/gatsby-theme-nacelle/README.md
+++ b/gatsby-theme-nacelle/README.md
@@ -26,13 +26,13 @@ Follow these steps to add `gatsby-theme-nacelle` to your Gatsby site:
 #### With Yarn
 
 ```shell
-yarn add gatsby-theme-nacelle
+yarn add @nacelle/gatsby-theme-nacelle
 ```
 
 #### With NPM
 
 ```shell
-npm i gatsby-theme-nacelle
+npm i @nacelle/gatsby-theme-nacelle
 ```
 
 ### Configure

--- a/gatsby-theme-nacelle/package.json
+++ b/gatsby-theme-nacelle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/gatsby-theme-nacelle",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Gatsby theme for loading data from the Nacelle Hail Frequency API",
   "keywords": [
     "gatsby",


### PR DESCRIPTION
The docs provided the incorrect install command because the `@nacelle` namespace was missing from the package name.